### PR TITLE
Release crawlee-one@3.0.2

### DIFF
--- a/.github/workflows/crawlee-one--release.yml
+++ b/.github/workflows/crawlee-one--release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Copy README into package
+        run: cp README.md packages/crawlee-one/README.md
+
       - name: Build
         run: pnpm build
 

--- a/packages/crawlee-one/CHANGELOG.md
+++ b/packages/crawlee-one/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release notes
 
+## v3.0.2
+
+_2026-02-09_
+
+#### Fix
+
+- Fix README copy in release workflow (move from prepublishOnly to CI step).
+
 ## v3.0.1
 
 _2026-02-09_

--- a/packages/crawlee-one/package.json
+++ b/packages/crawlee-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crawlee-one",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "private": false,
   "description": "Production-ready web scraping in a single function call. Built on Crawlee. Data transforms, caching, privacy compliance, and error tracking -- out of the box.",
@@ -59,7 +59,6 @@
     "start:prod": "node dist/index.js",
     "start:dev": "tsx ./src/index.ts",
     "build": "tsup && tsc -p tsconfig.build.json",
-    "prepublishOnly": "cp ../../README.md ./dist/README.md",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

Prepare release of crawlee-one@3.0.2.

## Checklist

- [x] Version in `package.json` matches the release.
- [x] Changelog entry exists and is accurate.
- [ ] CI passes.
- [ ] Draft GitHub Release is ready for review.

Made with [Cursor](https://cursor.com)