### PR TITLE
Release apify-actor-config@2.0.0-rc.0

### DIFF
--- a/packages/apify-actor-config/package.json
+++ b/packages/apify-actor-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apify-actor-config",
-  "version": "2.0.0",
+  "version": "2.0.0-rc.0",
   "type": "module",
   "private": false,
   "description": "Type-safe Apify Actor config. Full autocomplete, compile-time validation.",


### PR DESCRIPTION
## Summary

Bump version to `2.0.0-rc.0` for pre-release validation before the final `2.0.0` release.

Will be published to npm under the `rc` dist-tag (`npm install apify-actor-config@rc`). Existing users on `latest` are unaffected.

Made with [Cursor](https://cursor.com)